### PR TITLE
Allow using protobuf 4.x releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper"]
+requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.4.0"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
         python_requires=">=3.7",
-        install_requires=["grpcio~=1.17", "protobuf~=3.19"],
+        install_requires=["grpcio~=1.17", "protobuf>=3.19,<5"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={
             "": ["*.proto", "*.pyi", "py.typed", "VERSION"],


### PR DESCRIPTION
Relax the requirement on `protobuf`, to allow using its
4.x releases. See https://github.com/ansys-internal/ansys-api-template/issues/10.

Needs `ansys-tools-protoc-helper` release `0.4` or newer, 
to compile with `protoc` version `3.19`, see https://github.com/ansys-internal/ansys-tools-protoc-helper#upgrade-plans